### PR TITLE
URLに言語設定が追加されて正常に動かなくなっているのを修正

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ permissions:
 content_scripts:
   - matches:
       - 'https://atnd.ak4.jp/mypage/punch*'
+      - 'https://atnd.ak4.jp/*/mypage/punch*'
     js:
       - 'js/contentScript.js'
 icons:


### PR DESCRIPTION
表題通りです。
URLが `https://atnd.ak4.jp/ja/mypage/punch` になっていたので日本語以外でも対応可能なように言語のところに `*` を入れておきました。
手元では動作しています。